### PR TITLE
Release/0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.2.2] - In progress
+
 ## [v0.2.1] - 2025-08-08
 ### Changed
 - Updated azure.yaml to support azd deploy targeting the container app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
-## [v0.2.2] - In progress
+## [v0.2.2] - 2025-08-31
+### Changed
+- Standardized resource group variable as `AZURE_RESOURCE_GROUP`. [#365](https://github.com/Azure/GPT-RAG/issues/365)
 
 ## [v0.2.1] - 2025-08-08
 ### Changed

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -95,8 +95,8 @@ fi
 if ! containerRegistryLoginServer="$(get_config_value "CONTAINER_REGISTRY_LOGIN_SERVER")"; then
   missing_keys+=("CONTAINER_REGISTRY_LOGIN_SERVER")
 fi
-if ! resourceGroupName="$(get_config_value "RESOURCE_GROUP_NAME")"; then
-  missing_keys+=("RESOURCE_GROUP_NAME")
+if ! resourceGroupName="$(get_config_value "AZURE_RESOURCE_GROUP")"; then
+  missing_keys+=("AZURE_RESOURCE_GROUP")
 fi
 if ! mcpApp="$(get_config_value "MCP_APP_NAME")"; then
   missing_keys+=("MCP_APP_NAME")


### PR DESCRIPTION
This pull request standardizes the naming of the Azure resource group variable across the project, replacing all instances of `RESOURCE_GROUP_NAME` with `AZURE_RESOURCE_GROUP`. This change improves consistency and reduces confusion when configuring and deploying resources. The updates affect both PowerShell and Bash deployment scripts, as well as related documentation.

**Resource group variable standardization:**

* Updated the changelog to document the standardization of the resource group variable as `AZURE_RESOURCE_GROUP`.
* In `scripts/deploy.ps1`, replaced all references to `RESOURCE_GROUP_NAME` with `AZURE_RESOURCE_GROUP` for fetching configuration values, logging output, and Azure CLI commands. [[1]](diffhunk://#diff-6115bcb97665c4d2b99b1f5f4aa7b22673c6dbf7bc914d9ca8275670cca38b7eL9-R9) [[2]](diffhunk://#diff-6115bcb97665c4d2b99b1f5f4aa7b22673c6dbf7bc914d9ca8275670cca38b7eL128-R128) [[3]](diffhunk://#diff-6115bcb97665c4d2b99b1f5f4aa7b22673c6dbf7bc914d9ca8275670cca38b7eL156-R164) [[4]](diffhunk://#diff-6115bcb97665c4d2b99b1f5f4aa7b22673c6dbf7bc914d9ca8275670cca38b7eL252-R252) [[5]](diffhunk://#diff-6115bcb97665c4d2b99b1f5f4aa7b22673c6dbf7bc914d9ca8275670cca38b7eL265-R273)
* In `scripts/deploy.sh`, changed the required resource group key from `RESOURCE_GROUP_NAME` to `AZURE_RESOURCE_GROUP` for configuration retrieval and missing key checks.