### PR TITLE
Fix Docker build for Apple Silicon by adding --platform linux/amd64

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -126,6 +126,7 @@ echo
 
 echo -e "${GREEN}🛠️  Building Docker image…${NC}"
 docker build \
+  --platform linux/amd64 \
   -t "${containerRegistryLoginServer}/azure-gpt-rag/mcp:${tag}" \
   .
 


### PR DESCRIPTION
   ## Summary

   Adds `--platform linux/amd64` to the `docker build` call in `scripts/deploy.sh`.

   ## Problem

   When running `azd deploy` (or `scripts/deploy.sh`) from a Mac with Apple Silicon (M1/M2/M3/M4), Docker builds the image as `arm64` by default, causing `az containerapp update` to fail.

   ## Fix

   A single-line addition of `--platform linux/amd64` ensures the image is always built as `amd64`, consistent with the other components (`gpt-rag-ui`, `gpt-rag-orchestrator`, `gpt-rag-ingestion`) which already include this flag.

   Closes Azure/GPT-RAG#464